### PR TITLE
fix(publish-hoisted): add --conventional-commits for changelog generation

### DIFF
--- a/nx-actions/publish-hoisted/action.yml
+++ b/nx-actions/publish-hoisted/action.yml
@@ -177,8 +177,8 @@ runs:
         FORCE_PUBLISH=$(echo "$CHANGED_NAMES" | tr '\n' ',' | sed 's/,$//')
         echo "Force publish list: $FORCE_PUBLISH"
 
-        # Use patch bump for changed packages
-        npx lerna version patch --force-publish="$FORCE_PUBLISH" --no-git-tag-version --no-push --yes
+        # Use patch bump for changed packages with conventional commits for changelog generation
+        npx lerna version patch --conventional-commits --force-publish="$FORCE_PUBLISH" --no-git-tag-version --no-push --yes
 
         # Detect ALL packages that lerna bumped (including dependency cascade)
         # These are packages with modified package.json files


### PR DESCRIPTION
## Summary
- Adds `--conventional-commits` flag to `lerna version` command in publish-hoisted action
- This enables automatic CHANGELOG.md generation during publish based on conventional commit messages

## Problem
The `lerna version patch` command was missing `--conventional-commits`, so even though repos like `clients` have `changelogPreset` configured in `lerna.json`, changelogs were never being updated during CI publish.

## Fix
Changed line 181 from:
```bash
npx lerna version patch --force-publish="$FORCE_PUBLISH" --no-git-tag-version --no-push --yes
```

To:
```bash
npx lerna version patch --conventional-commits --force-publish="$FORCE_PUBLISH" --no-git-tag-version --no-push --yes
```

## Test plan
- [ ] Merge this PR
- [ ] Trigger a publish on a repo using publish-hoisted (e.g., clients)
- [ ] Verify CHANGELOG.md files are updated with new entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)