### PR TITLE
fix(content-pr-test): detect fork status from github context

### DIFF
--- a/.github/workflows/content-pr-test-reusable.yml
+++ b/.github/workflows/content-pr-test-reusable.yml
@@ -94,7 +94,7 @@ jobs:
         uses: zerobias-org/devops/nx-actions/content-validate@main
         with:
           test-timeout: ${{ inputs.test-timeout }}
-          is-fork: 'true'
+          is-fork: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
 
       - name: Delete Neon Branch
         if: always()


### PR DESCRIPTION
## Summary
- Replace hardcoded `is-fork: 'true'` in `content-pr-test-reusable.yml` with runtime fork detection via `github.event.pull_request.head.repo.full_name != github.repository`.
- Same-repo PRs (contributors with write access on the consuming repo) no longer trip the fork-only path restriction that limits changes to `package/` + `package-lock.json`.
- True fork PRs still hit the guardrail unchanged.

## Why
Discovered while merging the Gradle migration in `zerobias-org/vendor` (PR [#40](https://github.com/zerobias-org/vendor/pull/40)). That PR touches root-level infra (`build.gradle.kts`, `settings.gradle.kts`, gradle wrapper, `.github/workflows/publish.yml`, `.gitignore`). The reusable workflow rejected it with:

> File 'build.gradle.kts' is outside of the package/ directory — not allowed in forked PRs

even though the PR is from a same-repo branch. The path restriction is intended for forks; this fix makes it actually conditional on fork status.

## Test plan
- [ ] Re-run vendor PR #40 — same-repo + non-package files should pass the validation
- [ ] Sanity-check a fork PR (or a manual test) still trips the path guardrail