### PR TITLE
chore(zbb-publish-reusable): phase 1 — deprecate package-depth input

### DIFF
--- a/.github/workflows/zbb-publish-reusable.yml
+++ b/.github/workflows/zbb-publish-reusable.yml
@@ -26,14 +26,16 @@ on:
     inputs:
       package-depth:
         description: |
-          Directory depth from `package/` to the per-package
-          `build.gradle.kts`.
-          1 = package/<code>/build.gradle.kts            (vendor)
-          2 = package/<vendor>/<code>/build.gradle.kts   (module, suite,
-                                                          product, framework,
-                                                          collectorbot, …)
+          DEPRECATED — vestigial input, kept for backwards compatibility
+          with existing consumers that still pass it. The detect job no
+          longer uses this value: it walks UP from any changed file to
+          the nearest `build.gradle.kts`, which works at any depth and
+          handles mixed-depth repos (e.g. product, where some packages
+          are vendor-parented at depth 2 and others are suite-parented
+          at depth 3). New consumers should omit this input. A future
+          cleanup will remove it once all consumers stop passing it.
         type: number
-        required: true
+        required: false
       ghcr-namespace:
         description: |
           GHCR namespace for image publishes (e.g. `auditlogic`,
@@ -126,7 +128,6 @@ jobs:
       - name: Detect changed packages
         id: changed
         env:
-          PACKAGE_DEPTH: ${{ inputs.package-depth }}
           DISPATCH_VALUE: ${{ inputs.dispatch-input-value }}
           DISPATCH_NAME: ${{ inputs.dispatch-input-name }}
           PUSH_BEFORE_SHA: ${{ github.event.before }}
@@ -142,7 +143,6 @@ jobs:
           fi
 
           BRANCH="${GITHUB_REF#refs/heads/}"
-          FIND_DEPTH=$((PACKAGE_DEPTH + 1))
           ZERO_SHA="0000000000000000000000000000000000000000"
 
           # Pick the diff baseline:


### PR DESCRIPTION
## Why

`package-depth` is dead code. PR #9 (event.before baseline) replaced the previous find-by-depth no-tags fallback with a walk-up from each changed file to its nearest `build.gradle.kts`. The walk-up is inherently depth-agnostic and handles mixed-depth repos (e.g. \`org/product\`, where some packages are vendor-parented at depth 2 and others suite-parented at depth 3) without any input.

## Why three phases instead of one delete

Reusable workflows reject runs where:
- (a) a required input isn't passed, OR
- (b) an input is passed that the called workflow doesn't declare.

So a one-shot delete would break every consumer in the window between merging this PR and merging each consumer's cleanup. Three-phase rollout:

1. **(THIS PR)** \`required: true\` → \`required: false\`. Drop the now-dead \`PACKAGE_DEPTH\` env binding and \`FIND_DEPTH\` calc. Existing consumers (\`org/vendor\`, \`org/suite\`, \`auditlogic/module\`, \`auditlogic/collectorbot\`) keep passing it as a no-op.
2. **Phase 2** — each consumer drops its \`package-depth: N\` line in its own PR.
3. **Phase 3** — once Phase 2 lands everywhere, a follow-up here deletes the input declaration entirely.

## Changes

- \`.github/workflows/zbb-publish-reusable.yml\`:
  - \`package-depth\` description rewritten to flag the deprecation and direction (no new consumers should pass it).
  - \`required: true\` → \`required: false\`.
  - Removed \`PACKAGE_DEPTH: \${{ inputs.package-depth }}\` env binding.
  - Removed \`FIND_DEPTH=\$((PACKAGE_DEPTH + 1))\` calc (was unused after PR #9).

## Test plan

- [ ] Existing consumers continue to work with no change (input is now ignored).
- [ ] A consumer that omits \`package-depth\` runs successfully (validates that \`required: false\` took effect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)