### PR TITLE
chore(zbb-publish-reusable): phase 3 — remove deprecated package-depth input

### DIFF
--- a/.github/workflows/zbb-publish-reusable.yml
+++ b/.github/workflows/zbb-publish-reusable.yml
@@ -24,18 +24,6 @@ name: ZBB Publish (reusable)
 on:
   workflow_call:
     inputs:
-      package-depth:
-        description: |
-          DEPRECATED — vestigial input, kept for backwards compatibility
-          with existing consumers that still pass it. The detect job no
-          longer uses this value: it walks UP from any changed file to
-          the nearest `build.gradle.kts`, which works at any depth and
-          handles mixed-depth repos (e.g. product, where some packages
-          are vendor-parented at depth 2 and others are suite-parented
-          at depth 3). New consumers should omit this input. A future
-          cleanup will remove it once all consumers stop passing it.
-        type: number
-        required: false
       ghcr-namespace:
         description: |
           GHCR namespace for image publishes (e.g. `auditlogic`,


### PR DESCRIPTION
## Why

Final phase of the package-depth removal. All consumers have already stopped passing it, so the declaration is now safe to delete.

## Phase ledger

| Phase | What | Status |
|---|---|---|
| 1 | `required: true` → `required: false`; drop dead env binding + FIND_DEPTH calc | merged in #10 |
| 2 | Each consumer drops `package-depth: N` line | merged direct-to-main in: vendor `68faff8c`, suite `087cd7d`, auditlogic/module `54fd91929` (collectorbot still on inline workflow, no change needed) |
| 3 | THIS PR — remove the input declaration | open |

## Test plan

- [ ] After merge, the next push from any consumer (vendor/suite/module) runs the workflow successfully without the input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)