### PR TITLE
chore(actions): bump JS-based actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,18 +32,18 @@ jobs:
 
     steps:
       - name: Acquire cache v4
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .git
           key: repo-git-folder
 
       - name: Check out code v4
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Setup node v4
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'

--- a/.github/workflows/zbb-publish-reusable.yml
+++ b/.github/workflows/zbb-publish-reusable.yml
@@ -87,6 +87,12 @@ env:
   NEON_DB_ROLE: neondb_owner
   NEON_DB_NAME: zerobias
   CI: true
+  # Forces JS-based actions to run on Node 24. GitHub's June 2 2026 default
+  # flip is non-negotiable; this opts in early so we catch any regressions
+  # before the deadline. Belt-and-suspenders alongside the per-action major
+  # bumps below — actions still pinned to v4 (artifacts, slack, aws-creds)
+  # also get covered.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 permissions:
   contents: write
@@ -110,7 +116,7 @@ jobs:
       packages: ${{ steps.changed.outputs.packages }}
       has_changes: ${{ steps.changed.outputs.has_changes }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with: { fetch-depth: 0 }
 
       - name: Detect changed packages
@@ -213,7 +219,7 @@ jobs:
     outputs:
       sha: ${{ steps.bump.outputs.sha }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -221,7 +227,7 @@ jobs:
       # Vault auth — only the npm tokens. Version step does not push
       # images or hit Neon, so ECR/AWS/Neon secrets aren't needed here.
       - name: Authenticate to Vault
-        uses: hashicorp/vault-action@v3
+        uses: hashicorp/vault-action@v4
         with:
           url: ${{ secrets.VAULT_ADDR }}
           method: jwt
@@ -231,12 +237,12 @@ jobs:
             operations-kv/data/ci/github writePackagesToken | NPM_TOKEN;
             operations-kv/data/ci/github readPackagesToken  | READ_TOKEN;
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version-file: '.nvmrc'
           registry-url: 'https://npm.pkg.github.com'
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '21'
@@ -296,7 +302,7 @@ jobs:
       matrix:
         package: ${{ fromJson(needs.detect.outputs.packages) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -317,7 +323,7 @@ jobs:
         run: git checkout -B "${{ github.ref_name }}"
 
       - name: Authenticate to Vault
-        uses: hashicorp/vault-action@v3
+        uses: hashicorp/vault-action@v4
         with:
           url: ${{ secrets.VAULT_ADDR }}
           method: jwt
@@ -331,12 +337,12 @@ jobs:
             operations-kv/data/neon/content api-key         | NEON_API_KEY;
             operations-kv/data/neon/content project-id      | NEON_PROJECT_ID;
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version-file: '.nvmrc'
           registry-url: 'https://npm.pkg.github.com'
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '21'
@@ -358,19 +364,19 @@ jobs:
           done
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ env.NPM_TOKEN }}
 
       - name: Setup QEMU for multi-arch builds
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: arm64
 
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           driver: docker-container
           platforms: linux/amd64,linux/arm64
@@ -461,11 +467,11 @@ jobs:
       needs.publish.result == 'success'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version-file: '.nvmrc'
       - uses: zerobias-org/devops/actions/refresh-bundle@main
@@ -482,7 +488,7 @@ jobs:
       inputs.skip-sync != true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/actions/cdn-update/action.yml
+++ b/actions/cdn-update/action.yml
@@ -13,13 +13,13 @@ runs:
   using: "composite"
   steps:
     - name: check out code
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: .git
         key: ${{ github.repository }}-git-folder
 
     - name: check out code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
 

--- a/actions/content-dist-tag/action.yml
+++ b/actions/content-dist-tag/action.yml
@@ -9,7 +9,7 @@ runs:
   using: "composite"
   steps:
     - name: check out code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
         ref: ${{ github.ref_name }}

--- a/actions/content-pr-publish/action.yml
+++ b/actions/content-pr-publish/action.yml
@@ -4,13 +4,13 @@ runs:
   using: "composite"
   steps:
     - name: check out code
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: .git
         key: ${{ github.repository }}-git-folder
 
     - name: check out code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
         ref: ${{ github.ref_name }}

--- a/actions/content-pre-release/action.yml
+++ b/actions/content-pre-release/action.yml
@@ -9,7 +9,7 @@ runs:
   using: 'composite'
   steps:
     - name: check out code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
         ref: ${{ github.ref_name }}

--- a/actions/content-publish/action.yml
+++ b/actions/content-publish/action.yml
@@ -17,13 +17,13 @@ runs:
   using: 'composite'
   steps:
     - name: check out code
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: .git
         key: ${{ github.repository }}-git-folder
 
     - name: check out code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
 

--- a/actions/content-test-fork/action.yml
+++ b/actions/content-test-fork/action.yml
@@ -10,13 +10,13 @@ runs:
   using: "composite"
   steps:
     - name: check out code
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: .git
         key: ${{ github.repository }}-git-folder
 
     - name: check out code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         repository: ${{ github.event.pull_request.head.repo.full_name }}
         fetch-depth: 0

--- a/actions/content-test/action.yml
+++ b/actions/content-test/action.yml
@@ -10,13 +10,13 @@ runs:
   using: "composite"
   steps:
     - name: check out code
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: .git
         key: ${{ github.repository }}-git-folder
 
     - name: check out code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
         ref: ${{ github.head_ref }}

--- a/actions/static-s3-app-release/action.yml
+++ b/actions/static-s3-app-release/action.yml
@@ -34,10 +34,10 @@ runs:
   using: "composite"
   steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version-file: '.nvmrc'
 


### PR DESCRIPTION
## Summary

GitHub will force JS-based actions to run on Node 24 starting **June 2 2026** (~18 days from now). Every workflow run in our content/schema/vendor/suite repos has been emitting this annotation for weeks. This PR bumps the pinned action versions to their Node-24-compatible releases AND opts the runner into Node 24 NOW (via `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true`) so we catch any regression in the next CI cycles instead of on the deadline.

## Bumped (active `actions/` tree + `zbb-publish-reusable.yml`)

| action | old | new |
|---|---|---|
| `actions/checkout` | v4 | v5 |
| `actions/cache` | v4 | v5 |
| `actions/setup-node` | v4 | v5 |
| `actions/setup-java` | v4 | v5 |
| `docker/login-action` | v3 | v4 |
| `docker/setup-buildx-action` | v3 | v4 |
| `docker/setup-qemu-action` | v3 | v4 |
| `hashicorp/vault-action` | v3 | v4 |

All eight have Node 24 runtime in the noted version; semantics unchanged at the input/output level.

## Deferred (need breaking-change review)

These actions had non-trivial behavior changes between current-pin and Node-24-compatible release:

| action | current | reason to defer |
|---|---|---|
| `actions/upload-artifact` | v4 | v5 changed artifact naming behavior (one-vs-many) |
| `actions/download-artifact` | v4 | v5 changed artifact naming behavior |
| `aws-actions/configure-aws-credentials` | v4 | v5/v6 had semantic shifts in role assumption |
| `slackapi/slack-github-action` | v2.1.1 | v3 changed payload format |

These stay on their current versions and are covered by the env-var below.

## `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true`

Added at the workflow `env:` block in `zbb-publish-reusable.yml`. This is the documented opt-in for forcing Node 24 NOW on actions that still ship Node 20 in their manifest. After June 2 it becomes the default; opting in early surfaces any regression during a normal CI cycle.

## Not changed

The `nx-actions/` legacy tree (older `actions/setup-node@v3`, `docker/login-action@v1`, `aws-actions/configure-aws-credentials@v2`, `hashicorp/vault-action@v2.4.3`, `docker/setup-{buildx,qemu}-action@v2`) is left as-is. It's not invoked by current pipelines and is slated for removal.

## Test plan

- [ ] After merge: any push to a content repo (vendor/schema/suite) triggers a publish run that uses the new action versions and `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true`.
- [ ] Run completes without the Node-20-deprecation annotation banner.
- [ ] No new failures in matrix publish, update-bundle, or sync steps.

## Follow-up

Separate PR(s) for the 4 deferred actions, each with a tested upgrade path:
- artifacts v4 → v5: audit upload/download key naming
- aws-credentials v4 → v6: verify role-assumption / OIDC semantics
- slack-github-action v2 → v3: rewrite payload templates