### PR TITLE
feat(zbb-publish): export DISPATCH_TOKEN so modules re-trigger generate-kb

### DIFF
--- a/.github/workflows/zbb-publish-reusable.yml
+++ b/.github/workflows/zbb-publish-reusable.yml
@@ -326,6 +326,7 @@ jobs:
           secrets: |
             operations-kv/data/ci/github writePackagesToken | NPM_TOKEN;
             operations-kv/data/ci/github readPackagesToken  | READ_TOKEN;
+            operations-kv/data/ci/github dispatchToken      | DISPATCH_TOKEN;
             aws-auth/tools/ecr/creds/ecr-push access_key    | AWS_ACCESS_KEY_ID;
             aws-auth/tools/ecr/creds/ecr-push secret_key    | AWS_SECRET_ACCESS_KEY;
             operations-kv/data/neon/content api-key         | NEON_API_KEY;


### PR DESCRIPTION
## What

Pull the Vault `dispatchToken` into the `zbb-publish-reusable.yml` **publish** job as `DISPATCH_TOKEN` (one line in the existing vault-action `secrets:` block).

## Why

During the lerna→gradle migration, module repos lost their `scripts/postpublish.sh`, which fired a `generate-kb` `repository_dispatch` at the kb repo after every module publish. That regenerated each module's "Connect to <X>" KB (`kb-ct-<module>`). The gradle pipeline never replaced it, so **KB regeneration silently stopped** for modules published via zbb — the kb `generate-kb.yml` workflows still listen, but nothing fires them. (Those `ct-` KBs are publish-only artifacts, never committed to disk, so they're now frozen at their last lerna-era version.)

The companion build-tools PR adds a `dispatchGenerateKb` gradle task to `zb.typescript-connector` (schema-TS-twin-style pluggable step). That task reads `DISPATCH_TOKEN` from the env and **self-skips when it's absent** — so this workflow change is what actually wires it on in CI.

## Mechanism

`hashicorp/vault-action` exports secrets to `$GITHUB_ENV`, so `DISPATCH_TOKEN` is inherited by the `zbb publish` → gradle child process directly — same path `NPM_TOKEN` already takes (see the comment at the dependencies step). `operations-kv/data/ci/github dispatchToken` is the exact secret already used by `content-release-reusable.yml` and the nx publish workflows for cross-repo dispatch.

## Safety / ordering

Inert on its own (nothing reads `DISPATCH_TOKEN` until the build-tools task ships), so this is safe to merge first. Pairs with **zerobias-org/util#92**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)