### PR TITLE
fix(zbb-publish): upload logos to CDN on publish (restore dropped step)

### DIFF
--- a/.github/workflows/zbb-publish-reusable.yml
+++ b/.github/workflows/zbb-publish-reusable.yml
@@ -109,6 +109,10 @@ jobs:
     outputs:
       packages: ${{ steps.changed.outputs.packages }}
       has_changes: ${{ steps.changed.outputs.has_changes }}
+      # True only when a changed package dir carries a logo file. Lets the
+      # cdn-update job skip entirely on non-VSP repos (framework/crosswalk/
+      # standard/module/tag have no logos), so it doesn't spin a no-op job.
+      has_logos: ${{ steps.logos.outputs.has_logos }}
     steps:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
@@ -195,6 +199,25 @@ jobs:
           else
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
           fi
+
+      # Logos live only in VSP-type packages (vendor/suite/product/segment).
+      # Flag whether any changed package dir actually has one, so cdn-update
+      # runs only where it's relevant. Path-independent: reads the packages
+      # output, so it also covers the workflow_dispatch path above.
+      - name: Detect logo changes
+        id: logos
+        env:
+          PACKAGES: ${{ steps.changed.outputs.packages }}
+        run: |
+          set -euo pipefail
+          HAS=false
+          for rel in $(echo "$PACKAGES" | jq -r '.[]'); do
+            if ls "package/$rel"/logo.png "package/$rel"/logo.svg >/dev/null 2>&1; then
+              HAS=true; break
+            fi
+          done
+          echo "Changed packages include a logo: $HAS"
+          echo "has_logos=$HAS" >> "$GITHUB_OUTPUT"
 
   # ─── 2. Single-writer version bump (main only) ─────────────────────
   # Bumps every changed package's package.json + gate-stamp.json in ONE
@@ -467,7 +490,8 @@ jobs:
     needs: [detect, version, publish]
     if: |
       github.ref == 'refs/heads/main' &&
-      needs.publish.result == 'success'
+      needs.publish.result == 'success' &&
+      needs.detect.outputs.has_logos == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/zbb-publish-reusable.yml
+++ b/.github/workflows/zbb-publish-reusable.yml
@@ -454,10 +454,53 @@ jobs:
           SLACK_DEVOPS_NOTIFICATIONS: ${{ secrets.SLACK_DEVOPS_NOTIFICATIONS }}
           READ_TOKEN: ${{ env.READ_TOKEN }}
 
+  # ─── 3.5 CDN logo upload (main only) ───────────────────────────────
+  # Uploads each changed vendor/suite package's logo.{svg,png} to
+  # s3://auditmation-cdn/logos and rewrites index.yml `logo:`. Restores
+  # the postpublish step the lerna→gradle migration dropped (the
+  # nx-actions/cdn-update action already existed but was never wired in).
+  # The action skips any package dir without a logo file (frameworks,
+  # crosswalks, standards), so only vendor/suite logos upload. Sequenced
+  # before update-bundle so its index.yml commit lands before the bundle
+  # refresh, avoiding concurrent pushes to main.
+  cdn-update:
+    needs: [detect, version, publish]
+    if: |
+      github.ref == 'refs/heads/main' &&
+      needs.publish.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # Pick up the version-bump commit so the cdn commit stacks on
+          # the published state, not the pre-bump push SHA.
+          ref: ${{ needs.version.outputs.sha || github.sha }}
+      # Checkout at a SHA is detached HEAD; restore the branch so the
+      # action's add-and-commit can push back to main.
+      - name: Restore branch name
+        run: git checkout -B "${{ github.ref_name }}"
+      - name: Compute changed package dirs
+        id: dirs
+        env:
+          PACKAGES: ${{ needs.detect.outputs.packages }}
+        run: |
+          # detect emits paths relative to package/ (e.g. ["scf","scf/scf"]);
+          # the cdn-update action expects full package/<dir> paths.
+          DIRS=$(echo "$PACKAGES" | jq -r '.[] | "package/" + .' | tr '\n' ' ')
+          echo "Changed dirs: $DIRS"
+          echo "dirs=$DIRS" >> "$GITHUB_OUTPUT"
+      - name: CDN Update
+        uses: zerobias-org/devops/nx-actions/cdn-update@main
+        with:
+          changed-dirs: ${{ steps.dirs.outputs.dirs }}
+
   # ─── 4. Refresh bundle/package.json on successful main publish ─────
   update-bundle:
-    needs: publish
+    needs: [publish, cdn-update]
     if: |
+      always() &&
       github.ref == 'refs/heads/main' &&
       needs.publish.result == 'success'
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem
Newly published vendor/suite packages on the gradle/zbb pipeline point `index.yml` at a CDN logo URL that **404s** — e.g. the SCF Council vendor record on dev has `logo`/`imageUrl` = `https://cdn.auditmation.io/logos/scf.png`, which does not exist, so no logo renders.

## Root cause
The lerna→gradle/zbb migration **dropped the postpublish logo→CDN upload**:
- **Legacy:** `actions/content-publish` → `actions/cdn-update` ran `aws s3 cp <logo> s3://auditmation-cdn/logos/<name>` and rewrote `index.yml` `logo:`.
- **New:** `zbb-publish-reusable.yml` (detect → version → publish → update-bundle → sync) has **no** CDN step. A replacement action `nx-actions/cdn-update` already exists in this repo but was **never wired into the workflow** (0 references).

The dataloader does not upload logos, so loading a vendor never creates the asset — the URL just 404s.

## Fix
Add a `cdn-update` job (main only, after `publish`) that runs `nx-actions/cdn-update` for the changed package dirs (`package/<dir>` derived from `detect.outputs.packages`). The action:
- skips any dir without a `logo.{svg,png}` → frameworks/crosswalks/standards no-op; only vendor/suite logos upload;
- assumes the tools-account publishing role via OIDC and uploads to `s3://auditmation-cdn/logos/`;
- rewrites `index.yml` `logo:` and commits.

Sequenced **before** `update-bundle` (`update-bundle` now `needs: [publish, cdn-update]` with `always()`), so the two jobs don't race on pushing to `main`; a CDN failure won't block the bundle refresh.

Job graph: `detect → version → publish → cdn-update → update-bundle → sync`.

## Backfill note
This fixes publishes **going forward**. Existing already-published logos (e.g. `scf.png`) won't appear until their package republishes on main or the vendor/suite publish workflow is dispatched (the action supports `update-all`). Recommend a one-off `update-all` run for `org/vendor` + `org/suite` to backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)