### PR TITLE
fix(zbb-publish): has_logos must test each logo file independently

### DIFF
--- a/.github/workflows/zbb-publish-reusable.yml
+++ b/.github/workflows/zbb-publish-reusable.yml
@@ -212,7 +212,9 @@ jobs:
           set -euo pipefail
           HAS=false
           for rel in $(echo "$PACKAGES" | jq -r '.[]'); do
-            if ls "package/$rel"/logo.png "package/$rel"/logo.svg >/dev/null 2>&1; then
+            # test each file independently — `ls a b` exits non-zero when
+            # EITHER is missing, which false-negatived png-only packages.
+            if [ -f "package/$rel/logo.png" ] || [ -f "package/$rel/logo.svg" ]; then
               HAS=true; break
             fi
           done


### PR DESCRIPTION
Follow-up to #14. `ls png svg` exits non-zero when either file is missing, so PNG-only vendor/suite packages (no `logo.svg`) false-negatived `has_logos` and skipped `cdn-update` (seen on vendor-scf). Test each file with `[ -f ]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)