### PR TITLE
fix(zbb-publish): make sync skip-sync gate string-safe so sync runs on main

### DIFF
--- a/.github/workflows/zbb-publish-reusable.yml
+++ b/.github/workflows/zbb-publish-reusable.yml
@@ -549,7 +549,7 @@ jobs:
     if: |
       github.ref == 'refs/heads/main' &&
       needs.publish.result == 'success' &&
-      inputs.skip-sync != true
+      inputs.skip-sync != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

The post-publish **sync** job (`main → uat → qa → dev`) in `zbb-publish-reusable.yml` is **skipped on every main publish**, so downstream env branches never get propagated automatically.

Its gate compares the reusable-workflow boolean input against an **unquoted boolean literal**:

```yaml
sync:
  needs: [publish, update-bundle]
  if: |
    github.ref == 'refs/heads/main' &&
    needs.publish.result == 'success' &&
    inputs.skip-sync != true          # <-- here
```

Reusable-workflow inputs are delivered to the called workflow as **strings**, so `inputs.skip-sync` is the string `'false'` (the default — consumers don't pass it), and `'false' != true` does not evaluate the way `false != true` would. The gate fails and sync is skipped.

## Proof by elimination

The adjacent `update-bundle` job shares the *same* first two conditions and **runs fine**:

```yaml
update-bundle:
  if: |
    always() &&
    github.ref == 'refs/heads/main' &&     # same
    needs.publish.result == 'success'      # same
```

In real `auditlogic/module` main publishes, `update-bundle` succeeds while `sync` skips — and the **only** clause `sync` has that `update-bundle` lacks is `inputs.skip-sync != true`. So that clause is the one evaluating false. Confirmed across multiple main runs (e.g. the 5-module msgraph reconcile and a confluence publish). This is also why downstream branches have been **reconciled by hand** (`chore: reconcile main into qa …` commits).

Note the author already used the string-safe idiom one line up (`needs.publish.result == 'success'`, quoted); this just makes `skip-sync` consistent.

## Fix

```diff
-      inputs.skip-sync != true
+      inputs.skip-sync != 'true'
```

Behavior after fix:
- default / unset → `'false' != 'true'` → **true** → sync runs ✅
- `skip-sync: true` → `'true' != 'true'` → **false** → sync correctly skipped ✅

One-line change; no consumer workflow changes required.