### PR TITLE
fix(zbb-publish): install dataloader with --ignore-scripts

### DIFF
--- a/.github/workflows/zbb-publish-reusable.yml
+++ b/.github/workflows/zbb-publish-reusable.yml
@@ -286,7 +286,7 @@ jobs:
           npm i -g @zerobias-org/zbb
           # zbb's preflight requires platform-dataloader >=1.0.87
           # globally
-          npm i -g @zerobias-com/platform-dataloader
+          npm i -g @zerobias-com/platform-dataloader --ignore-scripts
 
       - name: Bootstrap zbb slot
         run: |
@@ -410,7 +410,7 @@ jobs:
           cp .npmrc $HOME/.npmrc
           cp .npmrc $NPM_CONFIG_USERCONFIG
           npm i -g @zerobias-org/zbb
-          npm i -g @zerobias-com/platform-dataloader
+          npm i -g @zerobias-com/platform-dataloader --ignore-scripts
 
       - name: Make gradlew executable
         run: chmod +x gradlew


### PR DESCRIPTION
## Problem

Every zbb repo's publish workflow is broken since **2026-07-19**. First failure: zerobias-org/benchmark run 29765132677 (`publish / version`, exit 127).

Chain:
1. `@zerobias-org/types-{core,amazon,google,microsoft}-js` dep `ip-num@^1.5.1`
2. `ip-num@1.6.1` (published 2026-07-19) added `preinstall: npx only-allow npm`
3. `npm i -g @zerobias-com/platform-dataloader` in the version/publish jobs resolves the fresh 1.6.1 → the preinstall's `npx` can't find its just-installed binary on the runner → `sh: 1: only-allow: not found`, exit 127

Local installs that predate 1.6.0 are unaffected, which is why gates pass locally.

## Fix

`--ignore-scripts` on both dataloader install lines (version job + publish job). The dataloader is pure JS with a bin entry — no lifecycle scripts needed — and this future-proofs against any other transitive package shipping hostile hooks. `@zerobias-org/zbb` doesn't pull types/ip-num, so its install line is untouched.

Longer-term (platform team): consider an `overrides: { "ip-num": "1.5.2" }` in the dataloader, or bumping types-*-js to pin a hook-free ip-num.