### PR TITLE
fix(refresh-bundle): tolerate unpublished/private packages and all-prerelease versions

### DIFF
--- a/actions/refresh-bundle/action.yml
+++ b/actions/refresh-bundle/action.yml
@@ -67,14 +67,19 @@ runs:
         for pkg_json in $(find . -path "./$PACKAGE_GLOB" -not -path "*/node_modules/*" -not -path "*/ts/*" | sort); do
           name=$(jq -r '.name // empty' "$pkg_json")
           [ -z "$name" ] && continue
+          # private packages (e.g. update/ fetchers) are never published — skip
+          [ "$(jq -r '.private // false' "$pkg_json")" = "true" ] && { echo "  [skip] $name (private)"; continue; }
           # Pin the newest *stable* release. `npm view <name> version` returns
           # whatever the `latest` dist-tag points at, and an untagged prerelease
           # publish (`x.y.z-rc.n`) moves `latest` — so trusting it lets rc/beta
           # builds leak into the bundle. Instead, list all versions, drop any
           # with a semver prerelease component (contains `-`), and take the max.
-          version=$(npm view "$name" versions --json --registry="$REGISTRY_URL" 2>/dev/null \
+          # Both npm view (exit 1 on E404 — npm-version-dependent) and grep -v
+          # (exit 1 when everything is a prerelease) must not kill the script
+          # under pipefail; empty results flow into the [skip] branch below.
+          version=$( (npm view "$name" versions --json --registry="$REGISTRY_URL" 2>/dev/null || true) \
             | jq -r '(if type=="array" then .[] else . end)' \
-            | grep -v -- '-' \
+            | { grep -v -- '-' || true; } \
             | sort -V | tail -1)
           if [ -z "$version" ]; then
             echo "  [skip] $name (no stable release)"


### PR DESCRIPTION
## Problem

zerobias-org/framework run 29768535684: `publish / update-bundle` dies ~6s in, exit 1, **zero output**.

Root cause: under `set -euo pipefail`, the version-lookup pipeline kills the whole script when:
1. `npm view` 404s — org/framework contains two `private: true` update-fetcher packages (`framework-complianceforge-scf-update`, `framework-opencre-opencre-update`) that are never published. The runner image bump on **2026-07-14** brought an npm whose `npm view` exits 1 on E404, which is why the same job was green on Jul 9 and dead on Jul 20 with no repo change (dies alphabetically right at `complianceforge`, ~6s in — matches the log timing).
2. `grep -v -- '-'` matching nothing (a package with only prerelease versions) — same silent death, latent.

## Fix

- Skip `private: true` packages explicitly (they can never be in the bundle)
- Wrap `npm view` + the prerelease filter in failure-tolerant guards so empty results flow into the existing `[skip] (no stable release)` branch

After merge: `gh run rerun 29768535684 --failed` in org/framework should turn its bundle + sync green. Second workflow fix today after #19 (ip-num preinstall) — both are runner-image-drift casualties.